### PR TITLE
renoir: overlay: Correct rounded corner mask & enable statusBarBurnInProtection

### DIFF
--- a/overlay/frameworks/base/core/res/res/values-land/dimens.xml
+++ b/overlay/frameworks/base/core/res/res/values-land/dimens.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+     Copyright (C) 2021 The LineageOS Project
+
+     SPDX-License-Identifier: Apache-2.0
+-->
+<resources>
+    <dimen name="status_bar_height">78px</dimen>
+</resources>

--- a/overlay/frameworks/base/core/res/res/values/dimens.xml
+++ b/overlay/frameworks/base/core/res/res/values/dimens.xml
@@ -11,5 +11,5 @@
     <dimen name="status_bar_height">104px</dimen>
 
     <!-- Radius of the software rounded corners of the display in it's natural orientation-->
-    <dimen name="rounded_corner_radius">94px</dimen>
+    <dimen name="rounded_corner_radius">96px</dimen>
 </resources>

--- a/overlay/frameworks/base/packages/SystemUI/res/drawable/rounded.xml
+++ b/overlay/frameworks/base/packages/SystemUI/res/drawable/rounded.xml
@@ -16,7 +16,7 @@
     android:viewportHeight="180.0"
 >
     <path
-        android:pathData="M 0 0 L 137 0 C 30 -1 -1 30 0 137 L 0 0 Z"
+        android:pathData="M 0 0 L 140 0 C 29 0 0 29 0 140 L 0 0 Z"
         android:fillColor="#000000"
     />
 </vector>

--- a/overlay/frameworks/base/packages/SystemUI/res/values-land/config.xml
+++ b/overlay/frameworks/base/packages/SystemUI/res/values-land/config.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+ * Copyright (c) 2006, The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+-->
+<resources>
+    <!-- StatusBar burn-in protection -->
+    <bool name="config_statusBarBurnInProtection">false</bool>
+</resources>

--- a/overlay/frameworks/base/packages/SystemUI/res/values-land/dimens.xml
+++ b/overlay/frameworks/base/packages/SystemUI/res/values-land/dimens.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+     Copyright (C) 2021 The LineageOS Project
+
+     SPDX-License-Identifier: Apache-2.0
+-->
+
+<resources>
+    <dimen name="status_bar_padding_top">0dp</dimen>
+    <dimen name="status_bar_padding_start">30px</dimen>
+    <dimen name="status_bar_padding_end">30px</dimen>
+</resources>

--- a/overlay/frameworks/base/packages/SystemUI/res/values/config.xml
+++ b/overlay/frameworks/base/packages/SystemUI/res/values/config.xml
@@ -29,4 +29,7 @@
     <bool name="config_roundedCornerMultipleRadius">true</bool>
 
     <string name="config_rounded_mask" translatable="false">M 140 0 C 29 0 0 29 0 140</string>
+
+    <!-- StatusBar burn-in protection -->
+    <bool name="config_statusBarBurnInProtection">true</bool>
 </resources>

--- a/overlay/frameworks/base/packages/SystemUI/res/values/config.xml
+++ b/overlay/frameworks/base/packages/SystemUI/res/values/config.xml
@@ -28,5 +28,5 @@
 
     <bool name="config_roundedCornerMultipleRadius">true</bool>
 
-    <string name="config_rounded_mask" translatable="false">M 27 0 C 5.3 -0.4 0 5.3 0 27</string>
+    <string name="config_rounded_mask" translatable="false">M 140 0 C 29 0 0 29 0 140</string>
 </resources>


### PR DESCRIPTION
Git history has been updated and fixed.

- [x] Correct rounded corner mask.
- [x] Enable `config_statusBarBurnInProtection` for portrait mode only.
- [x] Reduce status bar height on landscape mode.